### PR TITLE
domain: add custom domain to docs

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+stackerbuild.io


### PR DESCRIPTION
https://www.mkdocs.org/user-guide/deploying-your-docs/

this docs says we need to add the CNAME file to the docs dir as well for the gh-deploy to deploy correctly for custom domains.

Signed-off-by: Ravi Chamarthy <ravi@chamarthy.dev>