### PR TITLE
main page: fix twitter link

### DIFF
--- a/material/overrides/home.html
+++ b/material/overrides/home.html
@@ -11,7 +11,7 @@
         <div class="tx-hero__content">
           <h1>Stacker Build</h1>
           <p><strong>OCI-native</strong> container image builds, simplified </p>
-          <a href=https://twitter.com/stackerbuild">
+          <a href="https://twitter.com/stackerbuild">
             <span class="twemoji twitter">
               {% include ".icons/fontawesome/brands/twitter.svg" %}
             </span>


### PR DESCRIPTION
without the first ", this turns into a link to
https://twitter.com/stackerbuild" which doesn't work.